### PR TITLE
Configure Cloudflare Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,27 @@ All commands are run from the root of the project, from a terminal:
 ## 👀 Want to learn more?
 
 Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+
+## Deploying to Cloudflare Pages
+
+This project is configured for static hosting on [Cloudflare Pages](https://pages.cloudflare.com/).
+
+1. Install the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) if you have not already:
+
+   ```sh
+   npm install -g wrangler
+   ```
+
+2. Build the site locally:
+
+   ```sh
+   npm run build
+   ```
+
+3. Deploy the contents of `dist` to your Pages project:
+
+   ```sh
+   wrangler pages deploy ./dist --project-name <your-project-name>
+   ```
+
+Update `wrangler.toml` with your project name to simplify future deploys.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,5 +4,7 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   site: "https://onpardev.com",
+  // Explicitly set static output for Cloudflare Pages
+  output: "static",
 });
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "onpardev-site"
+pages_build_output_dir = "./dist"
+compatibility_date = "2025-06-17"


### PR DESCRIPTION
## Summary
- add Cloudflare Pages deployment notes
- configure Astro for static output
- add `wrangler.toml` for local `wrangler` support

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685174d1517c8323b2c6e8e68eaea03c