### PR TITLE
Add basic blog support

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,6 +12,7 @@
       <nav class="desktop-nav">
         <ul>
           <li><a href="#services">Services</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="#contact" class="btn">Contact</a></li>
         </ul>
       </nav>
@@ -26,10 +27,11 @@
   
   <div class="mobile-nav">
     <nav>
-      <ul>
-        <li><a href="#services">Services</a></li>
-        <li><a href="#contact" class="btn">Contact</a></li>
-      </ul>
+        <ul>
+          <li><a href="#services">Services</a></li>
+          <li><a href="/blog">Blog</a></li>
+          <li><a href="#contact" class="btn">Contact</a></li>
+        </ul>
     </nav>
   </div>
 </header>

--- a/src/content/blog/hello-world/index.md
+++ b/src/content/blog/hello-world/index.md
@@ -1,0 +1,7 @@
+---
+title: Hello, world
+date: "2024-01-01"
+description: First blog post
+---
+
+Welcome to my new blog created with Astro!

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,14 @@
+import { defineCollection, z } from 'astro:content';
+
+const blogCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.string(),
+    description: z.string().optional(),
+  }),
+});
+
+export const collections = {
+  blog: blogCollection,
+};

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,0 +1,47 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog')).sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+
+const formatDate = (dateStr) => {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+---
+
+<Layout title="Blog">
+  <section class="container">
+    <h1>Blog</h1>
+    <div class="posts">
+      {posts.map(post => (
+        <article class="post-preview">
+          <h2><a href={`/blog/${post.slug}`}>{post.data.title}</a></h2>
+          <p class="post-date">{formatDate(post.data.date)}</p>
+          <p>{post.data.description}</p>
+          <a class="btn" href={`/blog/${post.slug}`}>Read more</a>
+        </article>
+      ))}
+    </div>
+  </section>
+</Layout>
+
+<style>
+.posts {
+  display: grid;
+  gap: var(--space-8);
+}
+.post-preview {
+  background: white;
+  padding: var(--space-6);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+.post-preview h2 {
+  margin-top: 0;
+}
+.post-date {
+  color: var(--neutral-600);
+  margin-bottom: var(--space-4);
+}
+</style>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,41 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({ params: { slug: post.slug } }));
+}
+
+const { slug } = Astro.params;
+const post = (await getCollection('blog')).find(post => post.slug === slug);
+if (!post) {
+  throw new Error(`Post not found: ${slug}`);
+}
+const { Content } = await post.render();
+const formatDate = (dateStr) => new Date(dateStr).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+---
+
+<Layout title={post.data.title}>
+  <article class="container post">
+    <h1>{post.data.title}</h1>
+    <p class="post-date">{formatDate(post.data.date)}</p>
+    <Content />
+  </article>
+</Layout>
+
+<style>
+.post-date {
+  color: var(--neutral-600);
+  margin-bottom: var(--space-4);
+}
+.post {
+  background: white;
+  padding: var(--space-6);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+.post h1 {
+  margin-top: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- add blog link to the header
- configure Astro content collection
- create example blog post
- add blog listing and individual post pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68518adcaa908323a554a2b77f05e324