### PR TITLE
fix: Update CSP headers to allow inline scripts and Google Fonts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
         "Referrer-Policy": "no-referrer-when-downgrade",
-        "Content-Security-Policy": "default-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline';",
+        "Content-Security-Policy": "default-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;",
         "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
         "X-XSS-Protection": "1; mode=block"
       }
@@ -22,7 +22,7 @@ export default defineConfig({
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
         "Referrer-Policy": "no-referrer-when-downgrade",
-        "Content-Security-Policy": "default-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline';",
+        "Content-Security-Policy": "default-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;",
         "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
         "X-XSS-Protection": "1; mode=block"
       }

--- a/public/_headers
+++ b/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: no-referrer-when-downgrade
-  Content-Security-Policy: default-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline';
+  Content-Security-Policy: default-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-XSS-Protection: 1; mode=block


### PR DESCRIPTION
## Summary
- Fixed Content Security Policy blocking inline scripts from Astro components
- Added support for Google Fonts preconnect resources
- Updated both `public/_headers` and `astro.config.mjs` for consistency

## Changes
- `script-src`: Added `'unsafe-inline'` to allow Astro inline scripts (mobile menu, scroll animations)
- `font-src`: Added `https://fonts.gstatic.com` for Google Fonts
- `connect-src`: Added Google Fonts domains for preconnect

## Test plan
- [ ] Deploy to production
- [ ] Verify inline scripts execute without CSP errors
- [ ] Check browser console for CSP violations
- [ ] Test mobile menu functionality
- [ ] Test scroll animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)